### PR TITLE
Add testing section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,27 @@ class MyJob
 end
 ```
 
+### Testing
+
+Exceptions are only rescued when Sidekiq middleware is used. With that in mind, disable the Sidekiq test harness.
+
+```ruby
+require 'rails_helper'
+
+RSpec.describe MyJob do
+  before do
+    allow(ApiClient).to receive(:new).and_raise(ApiClient::SomethingWentWrongError)
+  end
+
+  it 'rescues the Error the job without raising' do
+    Sidekiq::Testing.disable! do
+      MyJob.perform_async(replicate_id)
+      MyJob.drain
+    end
+  end
+end
+```
+
 ## Motivation
 
 Sidekiq provides a retry mechanism for jobs that failed due to unexpected errors. However, it does not provide a way to retry jobs that failed due to expected errors. This gem aims to fill this gap.


### PR DESCRIPTION
This gem is great. Thanks so much for your work! 

I am just using it for the first time and struggled a bit to get a test to work. The test was raising an error and it wasn't rescued. It took me a few times of banging my head against the wall to realise that the sidekiq-rescue gem probably wasn't going to work if Sidekiq isn't actually used. 

I test a lot of my jobs with RSpec by just calling the perform method. That way I can test the logic inside of perform. In those cases jobs are not enqueued in Redis and picked up by Sidekiq. So I thought it would be useful to add this tidbit to the README. 

However, maybe there is a better approach I haven't thought of. I see the downsides to using Redis in tests. So, feel free to change or ignore this if it's not helpful. 